### PR TITLE
Add hashie gem to dependencies

### DIFF
--- a/grape-jbuilder.gemspec
+++ b/grape-jbuilder.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tilt"
   spec.add_dependency "tilt-jbuilder", ">= 0.4.0"
   spec.add_dependency "i18n"
+  spec.add_dependency "hashie", "~> 3.5"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "json_expressions"


### PR DESCRIPTION
Add [`hashie`](https://github.com/intridea/hashie) gem to dependencies. It is required not to fail at [here](https://github.com/milkcocoa/grape-jbuilder/blob/master/lib/grape/jbuilder.rb#L2). If not, I got this when I run `bundle exec rails c` :

```
$ bundle exec rails c
/Users/user/path/to/project/vendor/bundle/ruby/2.4.0/bundler/gems/grape-jbuilder-b6e8d3daef7f/lib/grape/jbuilder.rb:2:in `require': cannot load such file -- hashie/hash (LoadError)
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/bundler/gems/grape-jbuilder-b6e8d3daef7f/lib/grape/jbuilder.rb:2:in `<top (required)>'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.4/lib/bundler/runtime.rb:105:in `require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.4/lib/bundler/runtime.rb:105:in `rescue in block in require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.4/lib/bundler/runtime.rb:82:in `block in require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.4/lib/bundler/runtime.rb:75:in `each'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.4/lib/bundler/runtime.rb:75:in `require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.4/lib/bundler.rb:107:in `require'
	from /Users/user/path/to/project/config/application.rb:7:in `<top (required)>'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/railties-5.1.2/lib/rails/command/actions.rb:15:in `require'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/railties-5.1.2/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/railties-5.1.2/lib/rails/commands/console/console_command.rb:84:in `perform'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/railties-5.1.2/lib/rails/command/base.rb:63:in `perform'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/railties-5.1.2/lib/rails/command.rb:44:in `invoke'
	from /Users/user/path/to/project/vendor/bundle/ruby/2.4.0/gems/railties-5.1.2/lib/rails/commands.rb:16:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'

$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.12.4
BuildVersion:	16E195
```
